### PR TITLE
修复了 Vercel 部署前端的错误

### DIFF
--- a/src/modules/post/actions/postActions.ts
+++ b/src/modules/post/actions/postActions.ts
@@ -2,7 +2,7 @@
 
 import { BaseAction, HttpResponse } from '@shared/lib/api'
 import { Post, PostList } from '../types/Post'
-import { postService } from '../services/postService'
+import { postService } from '../services/PostService'
 import {
   CreatePostFormValues,
   UpdatePostFormValues

--- a/src/shared/lib/seo/api.ts
+++ b/src/shared/lib/seo/api.ts
@@ -1,5 +1,5 @@
 import { Post } from '@/modules/post/types/Post'
-import { postService } from '@/modules/post/services/postService'
+import { postService } from '@/modules/post/services/PostService'
 import { cache } from 'react'
 
 /**


### PR DESCRIPTION
**修复了 Vercel 部署前端的错误**（由两个 Typo 导致，但对 Windows 和 Mac OS 上的构建无影响）
原先的错误日志：
![image](https://github.com/user-attachments/assets/09d16247-c4ca-4c4e-ab9e-66089d213c18)
